### PR TITLE
Address OOM during LSQ sweep

### DIFF
--- a/full_sweep/eval_one.py
+++ b/full_sweep/eval_one.py
@@ -11,20 +11,22 @@ from datasets import load_dataset
 # ---------- CLI ----------
 p = argparse.ArgumentParser()
 p.add_argument("--model", required=True)
-p.add_argument("--data",  required=True)
+p.add_argument("--data", required=True)
 p.add_argument("--layer", type=int, required=True)
-p.add_argument("--head",  required=True, help="path to W for this layer")
+p.add_argument("--head", required=True, help="path to W for this layer")
 p.add_argument("--seq", type=int, default=256)
-p.add_argument("--rows", default="train[50000:55000]",
-               help="HF split spec for eval set")
+p.add_argument("--rows", default="train[50000:55000]", help="HF split spec for eval set")
 args = p.parse_args()
 
 # ---------- load ----------
 tok = AutoTokenizer.from_pretrained(args.model, padding_side="left")
 model = AutoModelForCausalLM.from_pretrained(
-           args.model, torch_dtype=torch.bfloat16,
-           device_map="cuda", attn_implementation="flash_attention_2").eval()
-W = torch.load(args.head, map_location="cuda")   # (V,d)
+    args.model,
+    torch_dtype=torch.bfloat16,
+    device_map="auto",
+    attn_implementation="flash_attention_2",
+).eval()
+W = torch.load(args.head, map_location="cuda")  # (V,d)
 
 test_ds = load_dataset("json", data_files=args.data, split=args.rows)
 
@@ -33,16 +35,18 @@ with torch.no_grad():
     for row in tqdm.tqdm(test_ds, desc=f"L{args.layer}"):
         if not row["conversations"]:
             continue
-        ids = tok(row["conversations"][0]["value"],
-                  return_tensors="pt", truncation=True,
-                  max_length=args.seq).to("cuda")
+        ids = tok(
+            row["conversations"][0]["value"],
+            return_tensors="pt",
+            truncation=True,
+            max_length=args.seq,
+        ).to("cuda")
 
         out = model(**ids, use_cache=False, output_hidden_states=True)
-        h   = out.hidden_states[args.layer + 1][:, -1, :]    # (1,d)
-        pred= (h @ W.T).argmax(-1)
-        gold= out.logits[:, -1, :].argmax(-1)
+        h = out.hidden_states[args.layer + 1][:, -1, :]  # (1,d)
+        pred = (h @ W.T).argmax(-1)
+        gold = out.logits[:, -1, :].argmax(-1)
         hits += (pred == gold).item()
-        tot  += 1
+        tot += 1
 
 print(f"Layer {args.layer} accept-rate: {hits/tot:.2%}")
-

--- a/full_sweep/fit_lsq.py
+++ b/full_sweep/fit_lsq.py
@@ -13,14 +13,35 @@ import tqdm
 import os
 import math
 
-p = argparse.ArgumentParser(description="Fit LSQ heads for all layers using batched layer processing on GPU.")
+p = argparse.ArgumentParser(
+    description="Fit LSQ heads for all layers using batched layer processing on GPU."
+)
 p.add_argument("--act_dir", required=True, help="Directory where dump_all.py stored *.pt shards")
-p.add_argument("--out_dir", required=True, help="Directory to write head files (e.g., h0.pt, h1.pt)")
+p.add_argument(
+    "--out_dir", required=True, help="Directory to write head files (e.g., h0.pt, h1.pt)"
+)
 p.add_argument("--lambda_", type=float, default=1e-4, help="Ridge factor for LSQ")
 p.add_argument("--gpu_id", type=int, default=0, help="GPU ID to use for computation")
-p.add_argument("--layers_per_batch", type=int, default=24, 
-               help="Number of layers to process in one batch (adjust based on GPU memory). Accumulators for these layers will be on GPU.")
+p.add_argument(
+    "--layers_per_batch",
+    type=int,
+    default=24,
+    help="Number of layers to process in one batch (adjust based on GPU memory). Accumulators for these layers will be on GPU.",
+)
+p.add_argument(
+    "--acc_dtype",
+    choices=["float32", "float16", "bfloat16"],
+    default="float16",
+    help="Data type for accumulation buffers. Using float16 reduces memory usage but may slightly affect accuracy.",
+)
 args = p.parse_args()
+
+dtype_map = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+acc_dtype = dtype_map[args.acc_dtype]
 print(f"Script called with arguments: {args}")
 
 shards = sorted(glob.glob(f"{args.act_dir}/b*.pt"))
@@ -32,14 +53,14 @@ print(f"Found {len(shards)} shards in {args.act_dir}")
 # --- Determine device for solving (GPU if available) ---
 if not torch.cuda.is_available():
     raise RuntimeError("CUDA not available. This script requires a GPU.")
-device = torch.device(f'cuda:{args.gpu_id}')
+device = torch.device(f"cuda:{args.gpu_id}")
 print(f"Using device: {device} for accumulation and solving.")
-torch.cuda.set_device(device) # Set default CUDA device
+torch.cuda.set_device(device)  # Set default CUDA device
 
 # --- Discover layers, d_model, and vocab_size from the first shard ---
 print("Inspecting first shard for metadata...")
 first_shard_path = shards[0]
-meta_blob = torch.load(first_shard_path, map_location='cpu')
+meta_blob = torch.load(first_shard_path, map_location="cpu")
 
 all_layer_keys = sorted([k for k in meta_blob.keys() if k.startswith("h")])
 if not all_layer_keys:
@@ -52,12 +73,14 @@ d_model = meta_blob[all_layer_keys[0]].shape[1]
 vocab_size = meta_blob["logits"].shape[1]
 num_total_layers = len(all_layer_keys)
 print(f"Discovered {num_total_layers} layers. d_model={d_model}, vocab_size={vocab_size}")
-del meta_blob # Free memory
+del meta_blob  # Free memory
 
 os.makedirs(args.out_dir, exist_ok=True)
 
 num_layer_batches = math.ceil(num_total_layers / args.layers_per_batch)
-print(f"Processing {num_total_layers} layers in {num_layer_batches} batches of up to {args.layers_per_batch} layers each.")
+print(
+    f"Processing {num_total_layers} layers in {num_layer_batches} batches of up to {args.layers_per_batch} layers each."
+)
 
 for batch_idx in range(num_layer_batches):
     start_layer_idx = batch_idx * args.layers_per_batch
@@ -67,16 +90,20 @@ for batch_idx in range(num_layer_batches):
     if not current_batch_layer_keys:
         continue
 
-    print(f"\n--- Processing Layer Batch {batch_idx+1}/{num_layer_batches} (Layers {current_batch_layer_keys[0]} to {current_batch_layer_keys[-1]}) ---")
+    print(
+        f"\n--- Processing Layer Batch {batch_idx+1}/{num_layer_batches} (Layers {current_batch_layer_keys[0]} to {current_batch_layer_keys[-1]}) ---"
+    )
 
     # --- Initialize accumulators on GPU for the current batch of layers ---
-    print(f"Initializing GPU accumulators (float32) for {len(current_batch_layer_keys)} layers in this batch...")
+    print(
+        f"Initializing GPU accumulators ({args.acc_dtype}) for {len(current_batch_layer_keys)} layers in this batch..."
+    )
     XtX_batch_gpu = {
-        layer_key: torch.zeros((d_model, d_model), dtype=torch.float32, device=device)
+        layer_key: torch.zeros((d_model, d_model), dtype=acc_dtype, device=device)
         for layer_key in current_batch_layer_keys
     }
     YtX_batch_gpu = {
-        layer_key: torch.zeros((vocab_size, d_model), dtype=torch.float32, device=device)
+        layer_key: torch.zeros((vocab_size, d_model), dtype=acc_dtype, device=device)
         for layer_key in current_batch_layer_keys
     }
     print("GPU accumulators for batch initialized.")
@@ -85,34 +112,36 @@ for batch_idx in range(num_layer_batches):
     # --- Accumulate XtX and YtX from all shards for the current batch of layers ---
     for shard_path in tqdm.tqdm(shards, desc=f"Shards (Batch {batch_idx+1})"):
         try:
-            blob = torch.load(shard_path, map_location='cpu') 
-            
+            blob = torch.load(shard_path, map_location="cpu")
+
             # Logits are common for all layers in this batch for this shard
-            Y_shard_cpu = blob["logits"] 
-            # Cast to float32 on GPU and clamp
-            current_logits_gpu = Y_shard_cpu.to(device=device, dtype=torch.float32)
-            current_logits_gpu.clamp_(-3000., 3000.) # Clamp large values
+            Y_shard_cpu = blob["logits"]
+            # Move to GPU with requested dtype and clamp
+            current_logits_gpu = Y_shard_cpu.to(device=device, dtype=acc_dtype)
+            current_logits_gpu.clamp_(-3000.0, 3000.0)  # Clamp large values
 
             for layer_key in current_batch_layer_keys:
                 if layer_key not in blob:
                     print(f"Warning: Layer {layer_key} not found in shard {shard_path}. Skipping.")
                     continue
-                
-                X_shard_layer_cpu = blob[layer_key]
-                # Cast to float32 on GPU and clamp
-                X_shard_layer_gpu = X_shard_layer_cpu.to(device=device, dtype=torch.float32)
-                X_shard_layer_gpu.clamp_(-3000., 3000.) # Clamp large values
 
-                # Perform matmuls with fp32 inputs, result is fp32, accumulate in fp32
-                XtX_batch_gpu[layer_key] += (X_shard_layer_gpu.T @ X_shard_layer_gpu)
-                YtX_batch_gpu[layer_key] += (current_logits_gpu.T @ X_shard_layer_gpu)
-                
-                del X_shard_layer_gpu 
+                X_shard_layer_cpu = blob[layer_key]
+                # Move to GPU with requested dtype and clamp
+                X_shard_layer_gpu = X_shard_layer_cpu.to(device=device, dtype=acc_dtype)
+                X_shard_layer_gpu.clamp_(-3000.0, 3000.0)  # Clamp large values
+
+                # Matmuls in the chosen dtype; accumulators share the same dtype
+                XtX_batch_gpu[layer_key] += X_shard_layer_gpu.T @ X_shard_layer_gpu
+                YtX_batch_gpu[layer_key] += current_logits_gpu.T @ X_shard_layer_gpu
+
+                del X_shard_layer_gpu
                 torch.cuda.empty_cache()
 
-            del blob, current_logits_gpu 
+            del blob, current_logits_gpu
         except Exception as e:
-            print(f"Error processing shard {shard_path} for layer batch {batch_idx+1}: {e}. Skipping shard.")
+            print(
+                f"Error processing shard {shard_path} for layer batch {batch_idx+1}: {e}. Skipping shard."
+            )
             continue
     print("Accumulation pass for current layer batch complete.")
 
@@ -122,45 +151,48 @@ for batch_idx in range(num_layer_batches):
         XtX_l_dev = XtX_batch_gpu[layer_key]
         YtX_l_dev = YtX_batch_gpu[layer_key]
 
-        A_l = (XtX_l_dev.to(torch.float32) + 
-               args.lambda_ * torch.eye(d_model, dtype=torch.float32, device=device))
-        
-        YtX_T_dev = YtX_l_dev.T # YtX_l_dev is already float32
-        
+        A_l = XtX_l_dev.to(torch.float32) + args.lambda_ * torch.eye(
+            d_model, dtype=torch.float32, device=device
+        )
+
+        YtX_T_dev = YtX_l_dev.to(torch.float32).T
+
         # Using torch.linalg.lstsq for robustness against singular matrices
         try:
             # Check for NaNs/Infs in A_l BEFORE the solve
             if not torch.isfinite(A_l).all():
-                print(f"Warning: NaNs or Infs detected in A_l for layer {layer_key} BEFORE lstsq. XtX condition: {torch.linalg.cond(XtX_l_dev) if torch.isfinite(XtX_l_dev).all() else 'N/A or Inf/NaN in XtX'}")
-            
+                print(
+                    f"Warning: NaNs or Infs detected in A_l for layer {layer_key} BEFORE lstsq. XtX condition: {torch.linalg.cond(XtX_l_dev) if torch.isfinite(XtX_l_dev).all() else 'N/A or Inf/NaN in XtX'}"
+                )
+
             # print(f"Attempting solve for {layer_key} with lambda={args.lambda_}. A_l condition number: {torch.linalg.cond(A_l) if A_l.shape[0] == A_l.shape[1] and torch.isfinite(A_l).all() else 'N/A or Inf/NaN'}")
-            
+
             lstsq_solution = torch.linalg.lstsq(A_l, YtX_T_dev)
             W_T_dev = lstsq_solution.solution
             W_l_dev = W_T_dev.T
             if torch.isnan(W_l_dev).any() or torch.isinf(W_l_dev).any():
-                print(f"Warning: NaNs or Infs detected in W_l_dev for layer {layer_key} after lstsq. This might indicate severe issues.")
+                print(
+                    f"Warning: NaNs or Infs detected in W_l_dev for layer {layer_key} after lstsq. This might indicate severe issues."
+                )
         except RuntimeError as e:
             print(f"torch.linalg.lstsq failed for layer {layer_key}: {e}")
             print(f"Skipping save for layer {layer_key} due to lstsq error.")
             # Optionally, save a zero matrix or skip saving
             # W_l_dev = torch.zeros_like(YtX_l_dev.T, dtype=torch.bfloat16, device='cpu') # Example: save zeros
-            continue # Skip saving this problematic layer
+            continue  # Skip saving this problematic layer
 
         output_filename = f"{layer_key}.pt"
         output_path = os.path.join(args.out_dir, output_filename)
-        
+
         try:
             torch.save(W_l_dev.to(torch.bfloat16).cpu(), output_path)
             # print(f"Saved: {output_path}") # tqdm provides progress
         except Exception as e:
             print(f"Error saving {output_path}: {e}")
 
-    
     print(f"Finished solving for layer batch {batch_idx+1}.")
-    del XtX_batch_gpu, YtX_batch_gpu # Free GPU memory for accumulators of this batch
+    del XtX_batch_gpu, YtX_batch_gpu  # Free GPU memory for accumulators of this batch
     torch.cuda.empty_cache()
 
 
 print("\nAll LSQ heads computed and saved.")
-

--- a/full_sweep/run_sweep.sh
+++ b/full_sweep/run_sweep.sh
@@ -9,7 +9,7 @@ MODEL_ID="meta-llama/Llama-4-Scout-17B-16E"
 DATA_FILE="/mnt/ss-decoding/datasets/sharegpt/ShareGPT_V3_unfiltered_cleaned_split.json"
 N_PROMPTS=50000            # train rows
 SEQ=256                    # trunc length
-BATCH=256                  # GPU batch during dump (Increased from 8 to 256)
+BATCH=32                   # GPU batch during dump
 LAYER_STEP=4               # evaluate every 4th layer
 GPUS=$(nvidia-smi -L | wc -l)   # auto-detect
 NUM_LAYERS=48              # Set to the total number of layers in your model
@@ -46,7 +46,8 @@ $PY fit_lsq.py \
    --out_dir "$HEAD_DIR" \
    --lambda_ "$FIT_LAMBDA" \
    --gpu_id 0 \
-   --layers_per_batch 16 \
+   --layers_per_batch 8 \
+   --acc_dtype float16 \
    2>&1 | tee "$LOG_DIR/fit_lsq_all_layers.log"
 # If the above tee command causes issues with tqdm rendering due to piping,
 # an alternative is to let tqdm print to stderr if fit_lsq.py is modified,


### PR DESCRIPTION
## Summary
- make accumulation dtype configurable for LSQ fit
- default to float16 accumulators and cast to fp32 only for solve
- reduce batch size and layers per batch in sweep script
- load evaluation model with device_map auto

## Testing
- `black full_sweep/fit_lsq.py --line-length 100`
- `black full_sweep/eval_one.py --line-length 100`
- `pytest -q` *(fails: command not found)*