### PR TITLE
Fix tokenizer padding in eval_one

### DIFF
--- a/full_sweep/eval_one.py
+++ b/full_sweep/eval_one.py
@@ -21,6 +21,8 @@ args = p.parse_args()
 
 # ---------- load ----------
 tok = AutoTokenizer.from_pretrained(args.model, padding_side="left")
+if tok.pad_token is None:
+    tok.pad_token = tok.eos_token
 model = AutoModelForCausalLM.from_pretrained(
            args.model, torch_dtype=torch.bfloat16,
            device_map="cuda", attn_implementation="flash_attention_2").eval()


### PR DESCRIPTION
## Summary
- ensure `eval_one.py` sets a pad token if the tokenizer doesn't define one

## Testing
- `git log -1 --stat`